### PR TITLE
Load menus in user order and only when visible

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -15,6 +15,8 @@
 		<script	src="lunch.js"></script>
 		<link rel="stylesheet" href="lunch.css">
 		<script>
+			checkLocalStorage();
+
 			$(document).ready(function() {
 				if (!isTouchDevice()) {
 					// Doesn't play well with touch devices. TODO make it more mobile friendly
@@ -37,11 +39,10 @@
 		
 				// load menus of all the restaurant
 				for (var i = 0 ; i < restaurants.length; i++) {
-					var restaurant = restaurants[i];
+					var restaurant = getRestaurant(localStorage["cz.redhat.oskutka.rhlp.order." + i + ".id"]);
 					$('div#' + restaurant.id).load(restaurant.url);
 				}
 			});
-			checkLocalStorage();
 		</script>
 	</head>
 	<body>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -37,11 +37,16 @@
 					$("#menus > div").collapsible( "option", "expandedIcon", "bars" );
 				}
 		
-				// load menus of all the restaurant
-				for (var i = 0 ; i < restaurants.length; i++) {
-					var restaurant = getRestaurant(localStorage["cz.redhat.oskutka.rhlp.order." + i + ".id"]);
-					$('div#' + restaurant.id).load(restaurant.url);
-				}
+				// load menus of all expanded restaurants
+				// ... queria: this was not needed in my case, as i had it already being loaded
+				// ...         by collapsible's initialization triggering on(collapsibleexpand)
+				// ...         if that's correct behaviour/assumption, then we can drop this code
+				// for (var i = 0 ; i < restaurants.length; i++) {
+				// 	restaurant = getRestaurant(localStorage["cz.redhat.oskutka.rhlp.order." + i + ".id"]);
+				// 	if( ! restaurant.isCollapsed() ) {
+				// 		$('div#' + restaurant.id).load(restaurant.url);
+				// 	}
+				// }
 			});
 		</script>
 	</head>
@@ -62,7 +67,11 @@
 								localStorage["cz.redhat.oskutka.rhlp." + event.target.lastChild.firstChild.id + ".collapsed"] = true;
 							});
 							newDiv.on("collapsibleexpand", function( event, ui ) {
-								localStorage["cz.redhat.oskutka.rhlp." + event.target.lastChild.firstChild.id + ".collapsed"] = false;
+								var restaurant = getRestaurant(event.target.lastChild.firstChild.id);
+								localStorage["cz.redhat.oskutka.rhlp." + restaurant.id + ".collapsed"] = false;
+								if($('div#' + restaurant.id).contents().length == 0) {
+									$('div#' + restaurant.id).load(restaurant.url);
+								}
 							});
 						}
 					</script>


### PR DESCRIPTION
By loading menu only for visible restaurants and exactly in the order as user sorted them,
provides feeling of way faster feedback as also can save a bit of traffic.